### PR TITLE
chore(backend): setup test in memory database and configuration

### DIFF
--- a/Backend-API/build.gradle
+++ b/Backend-API/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.postgresql:postgresql:42.7.2'
 }

--- a/Backend-API/src/test/resources/application.yml
+++ b/Backend-API/src/test/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: test-db-user
+    password: test-db-password
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true


### PR DESCRIPTION
If we are running the tests we rather should not connect currently to the database, which is configured via the `application.yaml`.

If we are putting an `application.yaml` in the `/test/resources` directory it will read that one instead. We want our tests to be self-contained and eliminate external dependencies and their state, so that we can use an embedded - or in-memory - database.

And it is fixing our current Application context.